### PR TITLE
Switch from using name/discriminator in logging to mentioning IDs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "admiral_bumblebot"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["porksausages <porksausages@icloud.com>"]
 edition = "2018"
 

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -30,7 +30,7 @@ pub async fn clean(ctx: &Context, msg: &Message, args: &str) {
                     .await
                     .expect("Error deleting messages");
 
-                let mut log_text = format!("🧼 {} messages cleaned by <@!{}>!", limit, author.id.0);
+                let mut log_text = format!("🧼 {} messages cleaned by <@!{}>!", limit, author.id.as_u64());
 
                 channel_id
                     .say(&ctx.http, &log_text)
@@ -47,8 +47,8 @@ pub async fn clean(ctx: &Context, msg: &Message, args: &str) {
 
                     log_text.push_str(
                         format!(
-                            "` ┣ {}#{}: {}`\n",
-                            author.name, author.discriminator, stripped_message
+                            "` ┣ <@!{}>: {}`\n",
+                            author.id.as_u64(), stripped_message
                         )
                         .as_str(),
                     )
@@ -60,8 +60,8 @@ pub async fn clean(ctx: &Context, msg: &Message, args: &str) {
 
                 log_text.push_str(
                     format!(
-                        "` ┗ {}#{}: {}`",
-                        author.name, author.discriminator, stripped_message
+                        "` ┗ <@!{}>: {}`",
+                        author.id.as_u64(), stripped_message
                     )
                     .as_str(),
                 );

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -47,7 +47,7 @@ pub async fn clean(ctx: &Context, msg: &Message, args: &str) {
 
                     log_text.push_str(
                         format!(
-                            "` ┣ <@!{}>: {}`\n",
+                            "` ┣ `<@!{}>`: {}`\n",
                             author.id.as_u64(), stripped_message
                         )
                         .as_str(),
@@ -60,7 +60,7 @@ pub async fn clean(ctx: &Context, msg: &Message, args: &str) {
 
                 log_text.push_str(
                     format!(
-                        "` ┗ <@!{}>: {}`",
+                        "` ┗ `<@!{}>`: {}`",
                         author.id.as_u64(), stripped_message
                     )
                     .as_str(),

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -43,7 +43,7 @@ impl EventHandler for Handler {
 
         logging::log(
             &ctx,
-            format!("📥 User joined: `{}`", new_member.distinct()).as_str(),
+            format!("📥 User joined: <@!{}>", new_member.user.id.as_u64()).as_str(),
         )
         .await;
     }
@@ -57,7 +57,7 @@ impl EventHandler for Handler {
     ) {
         logging::log(
             &ctx,
-            format!("📤 User left: `{}#{}`", user.name, user.discriminator).as_str(),
+            format!("📤 User left: <@!{}>`", user.id.as_u64()).as_str(),
         )
         .await;
     }
@@ -90,8 +90,8 @@ impl EventHandler for Handler {
             logging::log(
                 &ctx,
                 format!(
-                    "🗑 Message deleted in <#{}>: `{}#{}: {}`",
-                    channel_id, message.author.name, message.author.discriminator, stripped_message
+                    "🗑 Message deleted by <@!{}> in <#{}>:\n`{}`",
+                    message.author.id.as_u64(), channel_id, stripped_message
                 )
                 .as_str(),
             )
@@ -119,9 +119,8 @@ impl EventHandler for Handler {
             logging::log(
                 &ctx,
                 format!(
-                    "✏️ Message edited by `{}#{}` in <#{}>:\n` ┣ Original: {}`\n` ┗ Edited:   {}`",
-                    msg.author.name,
-                    msg.author.discriminator,
+                    "✏️ Message edited by <@!{}> in <#{}>:\n` ┣ Original: {}`\n` ┗ Edited:   {}`",
+                    msg.author.id.as_u64(),
                     msg.channel_id,
                     old_stripped,
                     new_stripped


### PR DESCRIPTION
Discord [recently announced](https://discord.com/blog/usernames) that names/discriminators are being removed in favor of a new username system. This PR will avoid any potential issues in the future if discriminators are no longer sent by the API, for example.

I have tested that this compiles however I haven't tried running it.