### PR TITLE
Stop pinging users in logging channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "admiral_bumblebot"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["porksausages <porksausages@icloud.com>"]
 edition = "2018"
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -2,7 +2,9 @@ use serenity::{model::id::ChannelId, prelude::Context};
 
 pub async fn log(ctx: &Context, message: &str) {
     if let Err(e) = ChannelId(get_env!("ABB_LOG_CHANNEL", u64))
-        .say(&ctx.http, message)
+        .send_message(&ctx.http, |msg| {
+            msg.content(message).allowed_mentions(|am| am.empty_parse())
+        })
         .await
     {
         eprintln!("Error sending message: {}", e);


### PR DESCRIPTION
This sets the allowed mentions field in the sent log messages to an empty list of users so the pings created by mentioning users (from #3) won't show up anymore.